### PR TITLE
added context (name, pos) to custom sort function params

### DIFF
--- a/src/VueExcelEditor.vue
+++ b/src/VueExcelEditor.vue
@@ -1643,7 +1643,7 @@ export default {
               }
         }
         this.value.sort((a, b) => {
-          return sorting(a, b) * -n
+          return sorting(a, b, n, colPos, name) * -n
         })
         this.sortPos = colPos
         this.sortDir = n


### PR DESCRIPTION
the params of the custom sort function are only a and b, each containing the whole row object. so no sort implementation is possible, because the right name is not passed. also this.sortDir and this.sortPos are not useable because they are only set after the sort.